### PR TITLE
[feat] Remember the last seen notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ CPMAddPackage("gh:nlohmann/json@3.11.3")
 CPMAddPackage("gh:emmaexe/emojicpp@2.0.0")
 include_directories("${emojicpp_SOURCE_DIR}")
 find_package(CURL REQUIRED)
+find_package(Boost REQUIRED COMPONENTS serialization)
 find_package(Qt6 REQUIRED COMPONENTS
     Core
     Gui
@@ -73,7 +74,7 @@ set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
 set(CPACK_RPM_PACKAGE_AUTOREQ TRUE)
 
 set(CPACK_DEBIAN_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}.deb")
-# TODO: Depends on Qt6/KF6 and libcurl, needs setting up for debian
+# TODO: Depends on Qt6/KF6, boost and libcurl, needs setting up for debian
 #set(CPACK_DEBIAN_PACKAGE_DEPENDS "")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "emmaexe <emma.git@emmaexe.moe>")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
@@ -98,7 +99,7 @@ qt_add_resources(RES_FILES "${RES_DIR}/resources.qrc")
 qt_add_executable(${CMAKE_PROJECT_NAME} ${SRC_FILES} ${MOC_FILES} ${RES_FILES})
 
 # Link libraries
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json emojicpp CURL::libcurl Qt6::Core Qt6::Gui Qt6::Widgets KF6::CoreAddons KF6::I18n KF6::Notifications)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json emojicpp CURL::libcurl Boost::serialization Qt6::Core Qt6::Gui Qt6::Widgets KF6::CoreAddons KF6::I18n KF6::Notifications)
 
 # Install files
 file(GLOB ICONS_SRC "${ICON_DIR}/*.png")

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ WIP
 
 ```bash
 dnf groupinstall "Development Tools"
-dnf install gcc-c++ cmake extra-cmake-modules libcurl-devel qt6-qtbase-devel kf6-kcoreaddons-devel kf6-ki18n-devel kf6-knotifications-devel rpm-build
+dnf install gcc-c++ cmake extra-cmake-modules boost-devel libcurl-devel qt6-qtbase-devel kf6-kcoreaddons-devel kf6-ki18n-devel kf6-knotifications-devel rpm-build
 ```
 
 #### Ubuntu

--- a/app/src/NotificationStore/NotificationStore.cpp
+++ b/app/src/NotificationStore/NotificationStore.cpp
@@ -1,0 +1,76 @@
+#include "NotificationStore.hpp"
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/string.hpp>
+
+#include <QCryptographicHash>
+#include <QStandardPaths>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+bool NotificationStore::initialized = false;
+std::map<std::string, std::string> NotificationStore::internalData = {};
+
+void NotificationStore::update(const std::string& domain, const std::string& topic, const std::string& notificationID) {
+    if (!NotificationStore::initialized) { NotificationStore::read(); }
+    std::string hash = QCryptographicHash::hash(QString::fromStdString(domain + "/" + topic).toUtf8(), QCryptographicHash::Sha256).toHex().toStdString();
+    NotificationStore::internalData[hash] = notificationID;
+    NotificationStore::write();
+}
+
+std::optional<std::string> NotificationStore::get(const std::string& domain, const std::string& topic) {
+    if (!NotificationStore::initialized) { NotificationStore::read(); }
+    std::string hash = QCryptographicHash::hash(QString::fromStdString(domain + "/" + topic).toUtf8(), QCryptographicHash::Sha256).toHex().toStdString();
+    if (NotificationStore::internalData.count(hash) == 0) { return std::nullopt; }
+    return NotificationStore::internalData[hash];
+}
+
+bool NotificationStore::exists(const std::string& domain, const std::string& topic) { return NotificationStore::get(domain, topic).has_value(); }
+
+void NotificationStore::remove(const std::string& domain, const std::string& topic) {
+    if (!NotificationStore::initialized) { NotificationStore::read(); }
+    std::string hash = QCryptographicHash::hash(QString::fromStdString(domain + "/" + topic).toUtf8(), QCryptographicHash::Sha256).toHex().toStdString();
+    if (NotificationStore::internalData.count(hash) != 0) {
+        NotificationStore::internalData.erase(hash);
+        NotificationStore::write();
+    }
+}
+
+void NotificationStore::read() {
+    if (!std::filesystem::exists(NotificationStore::getStorePath()) || !std::filesystem::is_directory(NotificationStore::getStorePath())) {
+        std::filesystem::create_directory(NotificationStore::getStorePath());
+        return;
+    }
+    if (!std::filesystem::exists(NotificationStore::getStoreFile())) { return; }
+
+    std::ifstream stream(NotificationStore::getStoreFile(), std::ios::in | std::ios::binary);
+    if (stream.is_open()) {
+        try {
+            boost::archive::binary_iarchive bindata(stream);
+            NotificationStore::internalData.clear();
+            bindata >> NotificationStore::internalData;
+        } catch (const std::exception& e) { std::cerr << "Error reading NotificationStore: " << e.what() << std::endl; }
+    }
+    stream.close();
+}
+
+void NotificationStore::write() {
+    if (!std::filesystem::exists(NotificationStore::getStorePath()) || !std::filesystem::is_directory(NotificationStore::getStorePath())) {
+        std::filesystem::create_directory(NotificationStore::getStorePath());
+    }
+    std::ofstream stream(NotificationStore::getStoreFile(), std::ios::out | std::ios::binary | std::ios::trunc);
+    if (stream.is_open()) {
+        try {
+            boost::archive::binary_oarchive bindata(stream);
+            bindata << NotificationStore::internalData;
+        } catch (const std::exception& e) { std::cerr << "Error writing NotificationStore: " << e.what() << std::endl; }
+    }
+    stream.close();
+}
+
+const std::string NotificationStore::getStorePath() { return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString(); }
+
+const std::string NotificationStore::getStoreFile() { return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).toStdString() + std::string("/NotificationStore.bin"); }

--- a/app/src/NotificationStore/NotificationStore.hpp
+++ b/app/src/NotificationStore/NotificationStore.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+/**
+ * @brief A static global class, holds the last seen notification.
+ */
+class NotificationStore {
+    public:
+        NotificationStore() = delete;
+        /**
+         * @brief Update a domain/topic with the ID of the last seen notification.
+         *
+         * @param domain The domain to update
+         * @param topic The topic to update
+         * @param notificationID The ID of the last seen notification for that domain/topic
+         */
+        static void update(const std::string& domain, const std::string& topic, const std::string& notificationID = "all");
+        /**
+         * @brief Get the last seen notification ID for some domain/topic.
+         *
+         * @param domain The domain to get
+         * @param topic The topic to get
+         * @return std::optional<std::string> - The ID of the last seen notification for that domain/topic. If there is no ID, returns `std::nullopt`.
+         */
+        static std::optional<std::string> get(const std::string& domain, const std::string& topic);
+        /**
+         * @brief Check if a last seen notification ID for some domain/topic exists.
+         *
+         * @param domain The domain to check
+         * @param topic The topic to check
+         */
+        static bool exists(const std::string& domain, const std::string& topic);
+        /**
+         * @brief Remove a domain/topic from the NotificationStore.
+         *
+         * @param domain The domain to remove
+         * @param topic The topic to remove
+         */
+        static void remove(const std::string& domain, const std::string& topic);
+    private:
+        static bool initialized;
+        static std::map<std::string, std::string> internalData;
+        static void read();
+        static void write();
+        static const std::string getStorePath();
+        static const std::string getStoreFile();
+};


### PR DESCRIPTION
Remember the last seen notification for some domain/topic, store its ID, and when starting back up fetch all available notifications (those that are still cached on the server)  that were sent since.