### PR TITLE
Fix notifications silently stopping after suspend/resume

### DIFF
--- a/app/src/ThreadManager/NtfyWorker.cpp
+++ b/app/src/ThreadManager/NtfyWorker.cpp
@@ -38,6 +38,14 @@ namespace NtfyWorker {
         curlInstance.setOpt(CURLOPT_CONNECTTIMEOUT, 10L);
         curlInstance.setOpt(CURLOPT_HTTPHEADER, headers.handle());
 
+        // Detect dead connections (e.g. after system suspend/resume or a network change), since
+        // ntfy's streaming endpoint otherwise leaves curl blocked forever reading from a stale socket.
+        curlInstance.setOpt(CURLOPT_TCP_KEEPALIVE, 1L);
+        curlInstance.setOpt(CURLOPT_TCP_KEEPIDLE, 60L);
+        curlInstance.setOpt(CURLOPT_TCP_KEEPINTVL, 60L);
+        curlInstance.setOpt(CURLOPT_LOW_SPEED_LIMIT, 1L);
+        curlInstance.setOpt(CURLOPT_LOW_SPEED_TIME, 120L);
+
         std::string url = std::format(
             "{}://{}/{}/{}",
             this->options.protocol == "https" || this->options.protocol == "http" || this->options.protocol == "wss" || this->options.protocol == "ws" ? this->options.protocol : "https",


### PR DESCRIPTION
  Fixes #78. Same root cause as #63 (network-change disconnects never trigger a reconnect).

  ## Root cause

  `BaseWorker::run()` (`app/src/ThreadManager/NtfyWorker.cpp`) holds a long-lived streaming
  connection to `/{topic}/json` via `curl_easy_perform()`, and only reconnects once that call
  *returns*. But `Curl::withDefaults()` (`app/src/Util/Curl.cpp`) never sets TCP keepalive or
  any idle-data timeout, so curl has no way to detect a dead socket. After suspend/resume (or
  a network change), the old TCP connection is often left half-open with no FIN/RST ever
  arriving — curl just blocks in `recv()` forever, so the reconnect loop never fires and
  notifications silently stop.

  ## Fix

  ```cpp
  curlInstance.setOpt(CURLOPT_TCP_KEEPALIVE, 1L);    // enable TCP keepalive probes
  curlInstance.setOpt(CURLOPT_TCP_KEEPIDLE, 60L);    // start probing after 60s of idle
  curlInstance.setOpt(CURLOPT_TCP_KEEPINTVL, 60L);   // then probe every 60s
  curlInstance.setOpt(CURLOPT_LOW_SPEED_LIMIT, 1L);  // fallback: if fewer than 1 byte/sec...
  curlInstance.setOpt(CURLOPT_LOW_SPEED_TIME, 120L); // ...for 120s straight, abort and retry
 ```

  TCP keepalive actively probes the connection and errors out if the peer/route is gone —
  the main fix for the post-suspend case. The low-speed watchdog is a fallback for cases
  where keepalive doesn't help (VPNs, some NAT setups): if zero bytes arrive for 120s (well
  above ntfy's ~45s keepalive interval, so no false positives during normal use), curl aborts
  on its own. Either way curl_easy_perform() returns an error instead of hanging forever,
  so the existing retry loop in NtfyWorker::makeRequest() reconnects exactly like it already
  does for any other connection error — no change to that logic was needed.

  Testing

  Verified on a real suspend/resume (~1h, Arch/KDE): notifications kept arriving after resume,
  where before this would go silent until an app restart.

  Note on #82

  This only touches NtfyWorker.cpp, a 5-line addition with no structural changes, so it
  should be trivial to rebase on top of the in-progress refactor if that lands first — happy
  to do so if it doesn't apply cleanly.
